### PR TITLE
Escape from no route maches plus add 204 response support

### DIFF
--- a/lib/watchdocs/rails/version.rb
+++ b/lib/watchdocs/rails/version.rb
@@ -1,5 +1,5 @@
 module Watchdocs
   module Rails
-    VERSION = '0.11.1'
+    VERSION = '0.11.2'.freeze
   end
 end


### PR DESCRIPTION
- Removed local rescue from method that checks routes and let the main middleware method catch it.
- Allow 204 responses to be recorded